### PR TITLE
Add library.properties metadata file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,0 +1,10 @@
+name=arduino-nes-controller
+version=0.0.0
+author=Richard Ramsden
+maintainer=Richard Ramsden
+sentence=NES controller library for Arduino.
+paragraph=
+category=Signal Input/Output
+url=https://github.com/rramsden/arduino-nes-controller
+architectures=*
+includes=NESController.h


### PR DESCRIPTION
Libraries in the Arduino Library 1.5 format (source files under the src subfolder) are required to have a library.properties file in the root folder. If this file is not present the library is not recognized by the Arduino IDE.

This file is also required for inclusion in the [Arduino Library Manager index](https://github.com/arduino/Arduino/wiki/Library-Manager-FAQ).

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#library-metadata